### PR TITLE
Example Script broken on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "eslint": "./node_modules/.bin/eslint src",
         "eslint-fix": "./node_modules/.bin/eslint --fix src",
         "precommit": "npm run eslint-fix",
-        "examples": "node_modules/http-server/bin/http-server examples/ -o"
+        "examples": "node ./node_modules/http-server/bin/http-server examples/ -o"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
This just changes the script for examples to use a relative path to work on Windows. 