### PR TITLE
add travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: node_js
+sudo: false
+node_js:
+    - "9"
+os:
+    - linux
+    - osx
+addons:
+    firefox: latest
+    chrome: stable
+script:
+    - npm test -- --verbose
+cache:
+    directories:
+        - node_modules
+# matrix:
+#     exclude:
+#         - os: osx # skip this because on Travis, node.js segfaults on osx+node 9
+#           node_js: "9"


### PR DESCRIPTION
Add Travis-CI builds.  The builds will only run eslint, but in the future it can run a build as well, and any tests we write.